### PR TITLE
Add SSH demo

### DIFF
--- a/demos/ssh-demo/Dockerfile
+++ b/demos/ssh-demo/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.14
+RUN apk update && apk upgrade && apk add openssh-server
+RUN ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -P ""
+# A password needs to be set for login to work. An empty password is
+# unproblematic as password-based login to root is not allowed.
+RUN passwd -d root
+# Generate with `ssh-keygen -t ed25519 -f ccv0-ssh -P "" -C ""`
+COPY ccv0-ssh.pub /root/.ssh/authorized_keys
+ENTRYPOINT /usr/sbin/sshd -D

--- a/demos/ssh-demo/README.md
+++ b/demos/ssh-demo/README.md
@@ -1,0 +1,48 @@
+# SSH demo
+
+To demonstrate confidential containers capabilities, we run a pod with SSH public key authentication.
+
+Compared to the execution of and login to a shell on a pod, an SSH connection is cryptographically secured and requires a private key.
+It cannot be established by unauthorized parties, such as someone who controls the node.
+The container image contains the SSH host key that can be used for impersonating the host we will connect to.
+Because this container image is encrypted, and the key to decrypting this image is only provided in measurable ways (e.g. attestation or encrypted initrd), and because the pod/guest memory is protected, even someone who controls the node cannot steal this key.
+
+## Building the container image
+
+The image built should be encrypted.
+To receive a decryption key at run time, the Confidential Containers project utilizes the [Attestation Agent](https://github.com/confidential-containers/attestation-agent).
+
+### Generating SSH keys
+
+```sh
+$ ssh-keygen -t ed25519 -f ccv0-ssh -P "" -C ""
+```
+
+generates an SSH key `ccv0-ssh` and the correspondent public key `ccv0-ssh.pub`.
+
+### Building the image
+
+The provided `Dockerfile` expects `ccv0-sh.pub` to exist.
+Using Docker, you can build with
+
+```sh
+$ docker build -t ccv0-ssh .
+```
+
+Alternatively, Buildah can be used (`buildah build` or formerly `buildah bud`).
+The SSH host key fingerprint is displayed during the build.
+
+## Connecting to the guest
+
+Running the image depends on your exact confidential containers setup.
+A Kubernetes YAML file specifying the [Kata Containers](https://github.com/kata-containers/kata-containers) runtime is included, but the image is still a placeholder at this time.
+With common CNI setups, on the same host, with the service running, you can connect via SSH with
+
+```sh
+$ ssh -i ccv0-ssh root@$(kubectl get service ccv0-ssh -o jsonpath="{.spec.clusterIP}")
+```
+
+You will be prompted about whether the host key fingerprint is correct.
+This fingerprint should match the one displayed in the Docker build.
+
+A `crictl`-compatible sandbox configuration is also included, which forwards the pod SSH port (22) to 2222 on the host (use the `-p` flag in SSH).

--- a/demos/ssh-demo/cri-sandbox-config.yaml
+++ b/demos/ssh-demo/cri-sandbox-config.yaml
@@ -1,0 +1,6 @@
+metadata:
+  name: ccv0-ssh-pod
+hostname: ccv0
+port_mappings:
+  - container_port: 22
+    host_port: 2222

--- a/demos/ssh-demo/k8s-cc-ssh.yaml
+++ b/demos/ssh-demo/k8s-cc-ssh.yaml
@@ -1,0 +1,28 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ccv0-ssh
+spec:
+  selector:
+    app: ccv0-ssh
+  ports:
+  - port: 22
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ccv0-ssh
+spec:
+  selector:
+    matchLabels:
+      app: ccv0-ssh
+  template:
+    metadata:
+      labels:
+        app: ccv0-ssh
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: ccv0-ssh
+        image: ${to_be_filled}
+        imagePullPolicy: Always


### PR DESCRIPTION
Add basic documentation, Dockerfile and sandbox config for a demo pod
with SSH public key authentication.

Documentation on encrypting and running the image is omitted as of now,
for this is a more general topic which will require separate attention.

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @sameo @fitzthum @magowan

We can also explain the setup in more detail, but I'd like your general opinion first. Feedback from code review over "this doesn't belong here" to "I have a better idea"  is welcome.