### PR TITLE
Document CCv0 demo image

### DIFF
--- a/demos/operator-demo/README.md
+++ b/demos/operator-demo/README.md
@@ -78,7 +78,7 @@ cc-operator-controller-manager-7f8d6dd988-t9zdm   2/2     Running   0          1
 ## Confidential Containers Runtime setup
 
 Creating a `CCruntime` object sets up the container runtime
-The default payload image sets up the CCv0 version of kata-containers runtime.
+The default payload image sets up the CCv0 demo image of the kata-containers runtime.
 
 ```yaml
 cat << EOF | kubectl create -f -
@@ -92,7 +92,7 @@ spec:
   runtimeName: kata
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:v0
+    payloadImage: quay.io/confidential-containers/runtime-payload:ccv0-ssh-demo
 EOF
 ```
 This will create an install daemonset targeting the worker nodes for installation.
@@ -117,3 +117,4 @@ kata-qemu   kata-qemu   92s
 `kata-cc` runtimeclass uses CCv0 specific configurations. 
 
 Now you can deploy the PODs targeting the specific runtimeclasses.
+The [SSH demo](/demos/ssh-demo) can be used as a compatible workload.

--- a/demos/ssh-demo/README.md
+++ b/demos/ssh-demo/README.md
@@ -10,6 +10,7 @@ Because this container image is encrypted, and the key to decrypting this image 
 ## Using a pre-provided container image
 
 If you would rather build the image with your own keys, skip to [Building the container image](#building-the-container-image).
+The [operator](/demos/operator-demo) can be used to set up a compatible runtime.
 
 A demo image is provided at [docker.io/katadocker/ccv0-ssh](https://hub.docker.com/r/katadocker/ccv0-ssh).
 It is encrypted with [Attestation Agent](https://github.com/confidential-containers/attestation-agent)'s [offline file system key broker](https://github.com/confidential-containers/attestation-agent/tree/64c12fbecfe90ba974d5fe4896bf997308df298d/src/kbc_modules/offline_fs_kbc) and [`aa-offline_fs_kbc-keys.json`](./aa-offline_fs_kbc-keys.json) as its key file.
@@ -49,7 +50,7 @@ The SSH host key fingerprint is displayed during the build.
 
 ## Connecting to the guest
 
-A [Kubernetes YAML file](./k8s-cc-ssh.yaml) specifying the [Kata Containers](https://github.com/kata-containers/kata-containers) runtime is included.
+A [Kubernetes YAML file](./k8s-cc-ssh.yaml) specifying the [`kata-cc`](https://github.com/kata-containers/kata-containers) runtime is included.
 If you use a [self-built image](#building-the-container-image), you should replace the image specification with the image you built.
 The default tag points to an `amd64` image, an `s390x` tag is also available.
 With common CNI setups, on the same host, with the service running, you can connect via SSH with

--- a/demos/ssh-demo/k8s-cc-ssh.yaml
+++ b/demos/ssh-demo/k8s-cc-ssh.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: ccv0-ssh
     spec:
-      runtimeClassName: kata
+      runtimeClassName: kata-cc
       containers:
       - name: ccv0-ssh
         image: docker.io/katadocker/ccv0-ssh


### PR DESCRIPTION
- In the operator documentation,
  - use the CCv0 demo image as payload,
  - reference the SSH demo.
- In the SSH demo documentation,
  - use the `kata-cc` runtime,
  - reference the operator demo.

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @bpradipt