### PR TITLE
docs: update CNCF Security White Paper references

### DIFF
--- a/TrustModel.md
+++ b/TrustModel.md
@@ -32,9 +32,9 @@ identifying where there may be considerations to preserve the value of using a T
 
 Further documentation will highlight specific [threat vectors](./ThreatsOverview.md) in detail, 
 considering risk, 
-impact, mitigation etc as the project progresses. The Security Assurance section, Page 32, of 
+impact, mitigation etc as the project progresses. The Security Assurance section, Page 31, of
 Cloud Native Computing Foundation (CNCF) 
-[Cloud Native Security Paper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/CNCF_cloud-native-security-whitepaper-Nov2020.pdf)
+[Cloud Native Security Paper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/CNCF_cloud-native-security-whitepaper-May2022-v2.pdf)
  will guide this more detailed threat vector effort.
 
 ### Related Prior Effort
@@ -48,7 +48,7 @@ For example:
   "[A Technical Analysis of Confidential Computing](https://confidentialcomputing.io/wp-content/uploads/sites/85/2021/03/CCC-Tech-Analysis-Confidential-Computing-V1.pdf)" 
   section 5 of which defines the threat model for confidential computing.
 - CNCF Security Technical Advisory Group published 
-  "[Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/CNCF_cloud-native-security-whitepaper-Nov2020.pdf)" 
+  "[Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/CNCF_cloud-native-security-whitepaper-May2022-v2.pdf)"
 - Kubernetes provides documentation :
   "[Overview of Cloud Native Security](https://kubernetes.io/docs/concepts/security/overview/)"
 - Open Web Application Security Project -


### PR DESCRIPTION
CNCF TAG-Security announced version 2 of the Security White Paper
and that broke the links to version 1.

Fix the links and move to v2 of the white paper..

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>