### PR TITLE
Seperate release notes and create quickstart guide

### DIFF
--- a/releases/v0.1.0.md
+++ b/releases/v0.1.0.md
@@ -1,0 +1,56 @@
+# Release Notes for v0.1.0
+This is the first full release of Confidential Containers.
+The goal of this release is to provide a stable, simple, and well-documented base for the Confidential Containers project.
+The Confidential Containers operator is the focal point of the release.
+The operator allows users to install Confidential Containers on an existing Kubernetes cluster.
+This release also provides core Confidential Containers features, such as being able to run encrypted containers on Intel-TDX and AMD-SEV.
+
+Please see the [quickstart guide](../quickstart.md) for details on how to try out Confidential Containers"
+
+## Hardware Support
+Confidential Containers is tested with attestation on the following platforms:
+- Intel TDX
+- AMD SEV
+
+The following platforms are untested or partially supported:
+- AMD SEV-ES
+- IBM Z SE
+
+The following platforms are in development:
+- Intel SGX
+- AMD SEV-SNP
+
+## Limitations
+
+The following are known limitations of this release:
+
+- Platform support is currently limited, and rapidly changing
+  * S390x is not supported by the CoCo operator
+  * AMD SEV-ES has not been tested.
+  * AMD SEV does not support container image signature validation.
+- Attestation and key brokering support is still under development
+  * The disk-based key broker client (KBC) is used when there is no HW support, but is not suitable for production (except with encrypted VM images).
+  * Currently, there are two KBS that can be used:
+    - simple-kbs:  simple key broker service (KBS) for SEV(-ES).
+    - [Verdictd](https://github.com/inclavare-containers/verdictd): An external project with which Attestation Agent can conduct remote attestation communication and key acquisition via EAA KBC
+  * The full-featured generic KBS and the corresponding KBC are still in the development stage.
+  * For developers, other KBCs can be experimented with.
+  * AMD SEV must use a KBS even for unencrypted images.
+- The format of encrypted container images is still subject to change
+  * The oci-crypt container image format itself may still change
+  * The tools to generate images are not in their final form
+  * The image format itself is subject to change in upcoming releases
+  * Image repository support for encrypted images is unequal
+- CoCo currently requires a custom build of `containerd`
+  * The CoCo operator will deploy the correct version of `containerd` for you
+  * Changes are required to delegate `PullImage` to the agent in the virtual machine
+  * The required changes are not part of the vanilla `containerd`
+  * The final form of the required changes in `containerd` is expected to be different
+  * `crio` is not supported
+- CoCo is not fully integrated with the orchestration ecosystem (Kubernetes, OpenShift)
+  * OpenShift is a non-started at the moment due to their dependency on CRIO
+  * Existing APIs do not fully support the CoCo security and threat model
+  * Some commands accessing confidential data, such as `kubectl exec`, may either fail to work, or incorrectly expose information to the host
+  * Container image sharing is not possible in this release
+  * Container images are downloaded by the guest (with encryption), not  by the host
+  * As a result, the same image will be downloaded separately by every pod using it, not shared between pods on the same host.


### PR DESCRIPTION
This splits the release notes into two files.

First, it creates a quickstart guide, which is an entry point for new users. This is a guide to basic CoCo features. It should be updated with future releases.

Second, it creates a release notes file. This contains information just about this release.

I think it was a bit odd to mix these two things together as one of them pertains just to this release and the other is long lasting. We don't want to have to copy all of the instructions from release to release. Instead we just move them to the quickstart guide and update as necessary.

I also made some tweaks to the documentation that was there. I reworded the use cases a little bit. I think they remain the same, but hopefully it is clearer now. I also added a section that lays out hardware support. I think it is important for new users to be able to understand exactly where the project stands with HW support even if they don't have the hardware. I don't think including this detracts from the ease-of-use. 

I also removed some of the limitations that have since been resolved and added a few that weren't on there yet.

There are still a lot of missing pieces. @ryansavino and I will add Kata information soon. 

@bpradipt I think we need to shorten the operator installation section significantly, especially since it's at the top of the document. 

We are also missing some pieces about running sample encrypted workloads with non-tee. Did we ever end up putting any keys into the rootfs? @stevenhorsman 

Also, I changed `COCO` -> `CoCo`. I can change this back if it makes people mad. Hopefully these are non-controversial changes given that we still need to add content to the guide.
