### PR TITLE
Release Notes: Add security limitations

### DIFF
--- a/releases/v0.1.0.md
+++ b/releases/v0.1.0.md
@@ -54,3 +54,12 @@ The following are known limitations of this release:
   * Container image sharing is not possible in this release
   * Container images are downloaded by the guest (with encryption), not  by the host
   * As a result, the same image will be downloaded separately by every pod using it, not shared between pods on the same host.
+- The CoCo community aspires to adopting open source security best practices, but not all practices are adopted yet.
+  * We track our status with the OpenSSF Best Practices Badge, which was at 43% at the time of this release.
+  * The main gaps are in test coverage, both general and security tests.
+  * Vulnerability reporting mechanisms also need to be created. Public github issues are still appropriate for this release until private reporting is established.
+
+
+## CVE Fixes
+
+None - This is our first release.


### PR DESCRIPTION
Add security limitations per badge tracking.
Add CVE section. While not relevant this release, we will have it in the template for next release.