### PR TITLE
Add instructions on how to deploy a single-node cluster locally

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -39,6 +39,8 @@ Confidential Containers is still maturing. See [release notes](./releases) for c
 
 You can enable Confidential Containers in an existing Kubernetes cluster using the Confidential Containers Operator.
 
+If you need to quickly deploy a single-node test cluster, you can use the [run-local.sh script](https://github.com/confidential-containers/operator/blob/main/tests/e2e/run-local.sh) from the operator test suite, which will setup a single-node cluster on your machine for testing purpose. This script requires `ansible-playbook`, which you can install on CentOS/RHEL using `dnf install ansible-core`, and the Ansible `docker_container` module, which you can get using `ansble-galaxy colection install community.docker`.
+
 * *TBD: we will move the below sections to the operator documentation and only refer to that link
 Installing the operator* *
 


### PR DESCRIPTION
We have a script that does most of the gruntwork as part of the CI, but can be used locally on a machine to quickly setup a single-node test cluster. Let's document that option.

Signed-off-by: Christophe de Dinechin <christophe@dinechin.org>
Suggested-by: Tobin Feldman-Fitzthum <tobin@ibm.com>