### PR TITLE
quickstart: Add a note about QEMU limitation with Kind / Minikube

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -36,6 +36,9 @@ get using `ansible-galaxy colection install community.docker`.
 > **Note** You can also use a Kind or Minikube cluster with containerd runtime to try out the CoCo stack
 for development purposes.  Make sure to use the `kata-clh` runtime class for your workloads when using Kind or
 Minikube, [as QEMU is known to **not** be working with Kind or Minikube](https://github.com/confidential-containers/operator/issues/124).
+Also, with the `enclave-cc` runtime class, the cluster must be prepared so that `/opt/confidential-containers`
+on the worker nodes is **not** on an overlayfs mount but the path is a `hostPath` mount (see
+[a sample configuration](https://github.com/confidential-containers/operator/blob/cf6a4f38114f7c5b71daec6cb666b1b40bcea140/tests/e2e/enclave-cc-kind-config.yaml#L6-L8))
 
 ## Prerequisites
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -34,7 +34,8 @@ This script requires `ansible-playbook`, which you can install on CentOS/RHEL us
 get using `ansible-galaxy colection install community.docker`.
 
 > **Note** You can also use a Kind or Minikube cluster with containerd runtime to try out the CoCo stack
-for development purposes.
+for development purposes.  Make sure to use the `kata-clh` runtime class for your workloads when using Kind or
+Minikube, [as QEMU is known to **not** be working with Kind or Minikube](https://github.com/confidential-containers/operator/issues/124).
 
 ## Prerequisites
 


### PR DESCRIPTION
It's a known limitation that QEMU based runtime classes will not work with Kind or Minikube, leading to:
```
Events:
  Type     Reason                  Age   From               Message
  ----     ------                  ----  ----               -------
  Normal   Scheduled               42s   default-scheduler  Successfully assigned default/nginx-kata-qemu to minikube
  Warning  FailedCreatePodSandBox  9s    kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: Failed to Check if grpc server is working: rpc error: code = DeadlineExceeded desc = timed out connecting to vsock 3189232285:1024: unknown
```

This needs further debug in order to get to the root cause of the issue, and potentially to a fix.  However, for now, we should make sure that we document such limitation.

One issue already reported about this is
https://github.com/confidential-containers/operator/issues/124, and that's also been observed by Pradipta during the early tests of v0.1.0.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>