### PR TITLE
Authenticated registry support

### DIFF
--- a/releases/v0.3.0.md
+++ b/releases/v0.3.0.md
@@ -6,7 +6,7 @@ Code Freeze: TBD
 Please see the [quickstart guide](../quickstart.md) for details on how to try out Confidential Containers
 
 ## What's new
-
+- Support for pulling images from authenticated container registries. See [design info](https://github.com/confidential-containers/image-rs/blob/main/docs/image_auth.md).
 
 ## Hardware Support
 Confidential Containers is tested with attestation on the following platforms:


### PR DESCRIPTION
Add new feature for authenticated registry support and point to the design docs. We might have more info on how to set it up in future but that is probably linked to configuration the guest image for offline_fs_kbc configuration in non-TEE scenario and separated for other confidential hardware, so we might need the quickstart guide to be broken down into separate topics first

Signed-off-by: stevenhorsman <steven@uk.ibm.com>