### PR TITLE
quickstart: Update to using kustomize with the ccruntime sample payloads

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -78,7 +78,19 @@ Creating a custom resource installs the required CC runtime pieces into the clus
 the `RuntimeClasses`
 
 ```
-kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
+kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/<CCRUNTIME_OVERLAY>?ref=<RELEASE_VERSION>
+```
+
+The current present overlays are: `default` and `s390x`
+
+For example, to deploy the `v0.3.0` release for `x86_64`, run:
+```
+kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/default?ref=v0.3.0
+```
+
+And to deploy `v0.3.0` release for `s390x`, run:
+```
+kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/s390x?ref=v0.3.0
 ```
 
 Wait until each pod has the STATUS of Running.
@@ -280,11 +292,11 @@ We have prepared a sample CoCo operator custom resource that is based on the sta
 
 Support for multiple custom resources in not available in the current release. Consequently, if a custom resource already exists, then you'll need to remove it first before deploying a new one. We can remove the standard custom resource with:
 ```
-kubectl delete -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
+kubectl delete -k github.com/confidential-containers/operator/config/samples/ccruntime/<CCRUNTIME_OVERLAY>?ref=<RELEASE_VERSION>
 ```
 and in it's place install the modified version with the sample container's decryption key:
 ```
-kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime-ssh-demo.yaml
+kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/ssh-demo?ref=<RELEASE_VERSION>
 ```
 Wait until each pod has the STATUS of Running.
 ```

--- a/quickstart.md
+++ b/quickstart.md
@@ -61,9 +61,9 @@ with the desired [release tag](https://github.com/confidential-containers/operat
 kubectl apply -k github.com/confidential-containers/operator/config/release?ref=<RELEASE_VERSION>
 ```
 
-For example, to deploy the `v0.2.0` release run:
+For example, to deploy the `v0.3.0` release run:
 ```
-kubectl apply -k github.com/confidential-containers/operator/config/release?ref=v0.2.0
+kubectl apply -k github.com/confidential-containers/operator/config/release?ref=v0.3.0
 ```
 
 Wait until each pod has the STATUS of Running.

--- a/quickstart.md
+++ b/quickstart.md
@@ -121,7 +121,7 @@ Details on each of the runtime classes:
 - *kata-clh* - standard kata runtime using the cloud hypervisor including all CoCo building blocks for a non CC HW
 - *kata-clh-tdx* - using the Cloud Hypervisor, with TD-Shim, and support for Intel TDX CC HW
 - *kata-qemu* - same as kata
-- *kata-qemu-tdx* - using QEMU, with TDVF, and support for Intel TDX CC HW
+- *kata-qemu-tdx* - using QEMU, with TDVF, and support for Intel TDX CC HW, prepared for using Verdictd and EAA KBC.
 - *kata-qemu-sev* - using QEMU, and support for AMD SEV HW
 
 For the process based CoCo TEE (aka. `enclave-cc`) the operator setup steps are the same and the custom resources

--- a/quickstart.md
+++ b/quickstart.md
@@ -42,7 +42,7 @@ on the worker nodes is **not** on an overlayfs mount but the path is a `hostPath
 
 ## Prerequisites
 
-- Ensure a minimum of 8GB RAM and 2 vCPU for the Kubernetes cluster node
+- Ensure a minimum of 8GB RAM and 4 vCPU for the Kubernetes cluster node
 - Only containerd runtime based Kubernetes clusters are supported with the current CoCo release
 - The minimum Kubernetes version should be 1.24
 - Ensure at least one Kubernetes node in the cluster is having the label `node-role.kubernetes.io/worker=`


### PR DESCRIPTION
During the `v0.3.0` development cycle we've changed to using kustomize with the ccruntime and ssh-demo sample payloads, so we need to reflect it here.

As the `v0.3.0` is not yet released, one can test the changed by using `4a41c6fd66921a2a56bbf7762d92cf37ddf568ed` as ref, as shown below:
```
kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/default?ref=4a41c6fd66921a2a56bbf7762d92cf37ddf568ed
```
Or, for s390x:
```
kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/s390x?ref=4a41c6fd66921a2a56bbf7762d92cf37ddf568ed
```