### PR TITLE
ssh-demo: Use KBS URI in demo

### DIFF
--- a/demos/ssh-demo/aa-offline_fs_kbc-keys.json
+++ b/demos/ssh-demo/aa-offline_fs_kbc-keys.json
@@ -1,3 +1,3 @@
 {
-  "key_id": "HUlOu8NWz8si11OZUzUJMnjiq/iZyHBJZMSD3BaqgMc="
+  "default/key/ssh-demo": "HUlOu8NWz8si11OZUzUJMnjiq/iZyHBJZMSD3BaqgMc="
 }

--- a/demos/ssh-demo/k8s-cc-ssh.yaml
+++ b/demos/ssh-demo/k8s-cc-ssh.yaml
@@ -24,5 +24,5 @@ spec:
       runtimeClassName: kata
       containers:
       - name: ccv0-ssh
-        image: docker.io/katadocker/ccv0-ssh
+        image: ghcr.io/confidential-containers/test-container:multi-arch-encrypted
         imagePullPolicy: Always


### PR DESCRIPTION
The offline_fs_kbc file needs to be updated to use a kbs-uri compatible name for the key, and the container image has been regenerated to reference the decryption key via kbs uri in it's annotation.

The image has two tags: encrypted and decrypted.

Fixes: kata-containers/kata-containers#6604