### PR TITLE
change the destination format when encrypting the image

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -452,7 +452,7 @@ tee > ocicrypt.conf <<EOF
 EOF
 
 # encrypt the image
-OCICRYPT_KEYPROVIDER_CONFIG=ocicrypt.conf skopeo copy --insecure-policy --encryption-key provider:attestation-agent docker://library/busybox dir:busybox:encrypted
+OCICRYPT_KEYPROVIDER_CONFIG=ocicrypt.conf skopeo copy --insecure-policy --encryption-key provider:attestation-agent docker://library/busybox oci:busybox:encrypted
 ```
 
 The image will be encrypted, and things happens in the KBS cluster background include:
@@ -463,7 +463,7 @@ The image will be encrypted, and things happens in the KBS cluster background in
 Then push the image to registry:
 
 ```shell
-skopeo copy dir:busybox:encrypted [SCHEME]://[REGISTRY_URL]:encrypted
+skopeo copy oci:busybox:encrypted [SCHEME]://[REGISTRY_URL]:encrypted
 ```
 Be sure to replace `[SCHEME]` with registry scheme type like `docker`, replace `[REGISTRY_URL]` with the desired registry URL like `docker.io/encrypt_test/busybox`.
 


### PR DESCRIPTION
When I use skopeo to encrypt the image from docker registry(_docker://_) to the local directory(_dir:_) named image, there is an error:
```
FATA[0003] copying system image from manifest list: Internal error: no candidate MIME types
```
Maybe this is a bug? Because there is no problem when the target format is _oci_.  And I found it's not a bug of CoCo. If this is a bug, we might be able to change the target format from dir to oci in the example.

My skopeo version:
```
skopeo version 1.11.1-dev commit: 2363dfeeabd53d5c4f1e244765116b1c611e2f29
```