### PR TITLE
Update cloud-api-adaptor link in release notes

### DIFF
--- a/releases/v0.5.0.md
+++ b/releases/v0.5.0.md
@@ -17,7 +17,7 @@ definition of the acronyms used in this document.
 - Process-based isolation is now fully supported with SGX hardware added to enclave-cc CI
 - Remote hypervisor support added to the CoCo operator, which helps to enable creating containers
 as ‘peer pods’, either locally, or on Cloud Service Provider Infrastructure.
-See [README](https://github.com/confidential-containers/cloud-api-adaptor/blob/staging/README.md) for more information and installation instructions.
+See [README](https://github.com/confidential-containers/cloud-api-adaptor/blob/v0.5.0/README.md) for more information and installation instructions.
 
 - [KBS Resource URI Scheme](https://github.com/confidential-containers/attestation-agent/blob/main/docs/KBS_URI.md) 
 is published to identify all confidential resources.


### PR DESCRIPTION
- Point to the released version of the Peer pods readme